### PR TITLE
added advice for compiling msgsteiner

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ instructions on how to download the library and extract files from the archive.
 To use the [Homebrew](http://brew.sh/) package manager for Mac simply type `brew install boost` to install the library.
 2. Download `msgsteiner-1.1.tgz` from http://areeweb.polito.it/ricerca/cmp/code/bpsteiner
 3. Unpack files from the archive: `tar -xvf msgsteiner-1.1.tgz`
-4. Enter the `msgsteiner-1.1` subdirectory and run make
-  * See below for advice on compiling the C++ code if you encounter problems. Make a note of the path to the compiled msgsteiner file that was created, which you will use when running Forest.
+4. Enter the `msgsteiner-1.1` subdirectory and run `make`
+  * See [this advice](./patches) on compiling the C++ code if you encounter problems. 
+  * Make a note of the path to the compiled msgsteiner file that was created, which you will use when running Forest.
 5. Download the Omics Integrator package: [OmicsIntegrator-0.2.0.tar.gz](./dist/OmicsIntegrator-0.2.0.tar.gz)
 6. Unpack files from the archive: `tar -xvzf OmicsIntegrator-0.2.0.tar.gz`
 7. Make sure you have all the requirements using the pip tool by entering the

--- a/patches/Makefile.bsd.patch
+++ b/patches/Makefile.bsd.patch
@@ -1,0 +1,35 @@
+--- Makefile.pristine	2012-08-20 10:00:39.000000000 -0500
++++ Makefile.new	2016-05-03 09:22:27.831590000 -0500
+@@ -1,6 +1,6 @@
+ MATLABDIR=/usr/local/MATLAB/R2012a/
+ 
++CXX=clang
+-CXXFLAGS=-Wall -O3 -g -Wno-deprecated -fopenmp -fPIC
++CXXFLAGS=-Wall -O3 -g -Wno-deprecated -fopenmp -fPIC -I/usr/local/include -L/usr/local/lib -lc++ -lm
+ #CXXFLAGS=-Wall -O3 -g -Wno-deprecated
+ LDFLAGS=-lboost_program_options -lgomp
+ DIST=*.?pp Makefile README LICENSE matlab
+@@ -10,6 +10,8 @@
+ 
+ BIN=msgsteiner ${MEXOBJ}
+ 
+ 
+ 
+ all: $(BIN)
+@@ -21,13 +23,13 @@
+ 	rm -rf msgsteiner-${VER}
+ 
+ msgsteiner: msgsteiner.cpp ms.o mes.o proba.hpp
+-	g++ ${CXXFLAGS} msgsteiner.cpp ${LDFLAGS} ms.o mes.o -o msgsteiner
++	$(CXX) ${CXXFLAGS} msgsteiner.cpp ${LDFLAGS} ms.o mes.o -o msgsteiner
+ clean:
+ 	rm -f $(BIN) *.o matlab/*.mexa64 matlab/*.mexglx .mlab *.tgz
+ mes.o: mes.cpp mes.hpp proba.hpp
+-	g++ ${CXXFLAGS} -c mes.cpp -o mes.o
++	$(CXX) ${CXXFLAGS} -c mes.cpp -o mes.o
+ ms.o: ms.cpp ms.hpp proba.hpp
+-	g++ ${CXXFLAGS} -c ms.cpp -o ms.o
++	$(CXX) ${CXXFLAGS} -c ms.cpp -o ms.o
+ 
+ .mlab: matlab.cpp ms.o mes.o
+ 	${MATLABDIR}/bin/mex matlab.cpp -output matlab/MsgSteiner -v -g -O -largeArrayDims -lut "CXXFLAGS=\$$CXXFLAGS ${CXXFLAGS}" "LDFLAGS=\$$LDFLAGS ${LDFLAGS} ms.o mes.o -lgomp" \

--- a/patches/Makefile.linux.patch
+++ b/patches/Makefile.linux.patch
@@ -1,0 +1,11 @@
+--- Makefile.pristine	2016-06-14 21:18:35.574015197 -0500
++++ Makefile.new	2016-05-08 21:35:06.250533424 -0500
+@@ -2,7 +2,7 @@
+ 
+ CXXFLAGS=-Wall -O3 -g -Wno-deprecated -fopenmp -fPIC
+ #CXXFLAGS=-Wall -O3 -g -Wno-deprecated
+-LDFLAGS=-lboost_program_options -lgomp
++LDFLAGS=-L/usr/lib -I/usr/include -lboost_program_options
+ DIST=*.?pp Makefile README LICENSE matlab
+ #CXXFLAGS=-Wall -O0 -g -ffloat-store
+ #CXXFLAGS=-Wall -O2 -g -ffloat-store

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,17 @@
+# Patches
+
+[msgsteiner](http://areeweb.polito.it/ricerca/cmp/code/bpsteiner) does not compile on many 
+systems with the default Makefile provided in its source distribution.
+
+In this directory we have prepared patches for various systems to resolve common compilation issues.
+
+If compilation of msgsteiner fails on your system, download the patch file associated with 
+your operating system, place it in the directory with the msgsteiner source code, run the `patch` command,
+and try the build again with `make`:
+
+```bash
+cd msgsteiner-1.1
+wget "https://github.com/fraenkel-lab/OmicsIntegrator/tree/master/patches/Makefile.linux.patch"
+patch Makefile Makefile.linux.patch
+make
+```


### PR DESCRIPTION
@agitter mentioned that these patch files could be helpful for users who are having trouble compiling _msgsteiner_. I added some notes about how to make use of the patch files and updated the root README.md to link to those notes.