### PR TITLE
Garnet output

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,13 @@ garnet script.
   regression.
 
 - **events_to_genes_with_motifsregression_results_FOREST_INPUT.tsv**: Only those
-  results from the regression that fall under a provided significance threshold,
-  e.g. p=0.05.  This file can be used as input to forest.
+  regression results that fall under the p-value or q-value significance
+  threshold provided in the configuration file, e.g. p=0.05, are included.
+  This file can be used as input to Forest, and the prizes are -log2(pval)
+  or -log2(qval).
 
 - **regression_plots**: An optional subdirectory that contains plots visualizing
-the transcription factor linear regression tests.
+  the transcription factor linear regression tests.
 
 Running forest.py
 -----------------

--- a/scripts/garnet.py
+++ b/scripts/garnet.py
@@ -5,7 +5,7 @@ GARNET primary script executes 5 sub scripts according to provided configuration
 --------------------------------------------------------------------
 Config file:
 --------------------------------------------------------------------
-Configuration file should have 11 different varaibles provided.
+Configuration file should provide the following variables.
 [chromatinData]
 bedfile=[bed file of accessible chromatin regions]
 fastafile=[fasta file of same regions, collected via galaxyweb]
@@ -26,6 +26,9 @@ tfDelimiter=.
 expressionFile=[name of expression file]
 pvalThresh=0.01
 qvalThresh=
+
+[regression]
+savePlot=False
 =======================================================================
 
 '''

--- a/scripts/garnet.py
+++ b/scripts/garnet.py
@@ -155,7 +155,10 @@ def getTfsFromRegression(pickle_file,expressionfile,pvalT,qvalT,plot):
         else:
             thresh=pvalT
         cmd+=' --thresh='+thresh
-        cmd+=' --plot='+plot
+        
+        if plot:        
+            cmd+=' --plot'
+
         print '\n-----------------------------Regression Output------------------------------------------\n'
         print 'Running command:\n'+cmd+'\n'
         res=os.system(cmd)
@@ -247,7 +250,7 @@ def main():
     if delim is None:##here we want no delimiter if we do not want to tease out individual tfs
         delim=''
 
-    if do_network is not None and do_network!='' and do_network!='False':
+    if do_network is not None and do_network!='' and do_network.lower()!='false':
         cmd='python '+os.path.join(progdir,'zipTgms.py')+' --pkl='+binding_matrix+' --genome '+genome+' --as-network --tf-delimiter='+delim
         if opts.allgenes:
             cmd=cmd+' --allGenes'
@@ -256,7 +259,11 @@ def main():
         
     pvt=config.get('expressionData','pvalThresh')
     qvt=config.get('expressionData','qvalThresh')
-    plot=config.get('regression','savePlot')
+    
+    plot = False
+    plot_str=config.get('regression','savePlot')
+    if plot_str is not None and plot_str != '' and plot_str.lower() != 'false':
+        plot = True
     
     ##step 4: regression
     if expr is not None and expr!='':

--- a/scripts/motif_regression.py
+++ b/scripts/motif_regression.py
@@ -168,7 +168,7 @@ def main():
     parser.add_option('--thresh',dest='thresh',type='string',default='0.9',help='P/Q-Value threshold to illustrate results. Default:%default')
     parser.add_option('--gifdir',dest='motifs',default=os.path.join(progdir,'../data/matrix_files/gifs'),
                       help='Directory containing motif GIFs to illustrate results. Default is %default')
-    parser.add_option('--plot',dest='plot',type='string',default=False,help='Enable plot generation for regression results.')
+    parser.add_option('--plot',dest='plot',action='store_true',default=False,help='Enable plot generation for regression results. Default:%default')
 
     # get options, arguments
     (opts,args) = parser.parse_args()
@@ -305,7 +305,7 @@ def main():
                 regdict[tf]=lpv
     print 'Found '+str(len(regdict))+'Tf scores for '+str(len(new_results))+' motif results'
     of=open(re.sub('.tsv','_FOREST_INPUT.tsv',outdir),'w')
-    for tf in regdict.keys():
+    for tf in sorted(regdict.keys()):
         val=regdict[tf]
         of.write(tf+'\t'+str(val)+'\n')
     of.close()

--- a/scripts/motif_regression.py
+++ b/scripts/motif_regression.py
@@ -164,7 +164,7 @@ def main():
     parser.add_option('--norm-type',dest='norm_type',default=None,
                       help='Choose normalization type for response data. Choices are: "log2", "log10".\
                             Default is %default.')    
-    parser.add_option('--use-qval',dest='use_qval',action='store_true',default=False,help='If set this the FOREST input file will contain -log(qval) instead of -log(pval). Default:%default')
+    parser.add_option('--use-qval',dest='use_qval',action='store_true',default=False,help='If set this the Forest input file will contain -log(qval) instead of -log(pval) and threshold the output using qval. Default:%default')
     parser.add_option('--thresh',dest='thresh',type='string',default='0.9',help='P/Q-Value threshold to illustrate results. Default:%default')
     parser.add_option('--gifdir',dest='motifs',default=os.path.join(progdir,'../data/matrix_files/gifs'),
                       help='Directory containing motif GIFs to illustrate results. Default is %default')
@@ -254,6 +254,7 @@ def main():
     of.close()
 
     ##now create HTML writeup
+    threshold = float(opts.thresh)
     of= open(re.sub(outdir.split('.')[-1],'html',outdir),'w')
     of.writelines("""<html>
                      <title>GARNET Results</title>
@@ -264,8 +265,9 @@ def main():
                 """)
     for res in new_results:
         if str(res[1])=='nan':
-            continue    
-        if res[4]<float(opts.thresh):
+            continue
+        # skip rows that exceed the q-value or p-value threhsold
+        if (opts.use_qval and res[4]<=threshold) or ((not opts.use_qval) and res[2]<=threshold):
             motifgif=os.path.join(opts.motifs,'motif'+str(res[3])+'.gif')
             ostr = "<tr><td>"+' '.join(res[0].split('.'))+"</td><td>"+str(res[1])+'</td><td>'+str(res[2])+"</td><td>"+str(res[4])+"</td><td><img src=\""+motifgif+"\" scale=80%></td></tr>\n"
             of.writelines(ostr)
@@ -273,26 +275,28 @@ def main():
     of.close()
     
     
-    ##now write to FOREST-friendly input file
+    ##now write to Forest-friendly input file
     ##collect dictionary of all individual tf names and their regression p-values
+    ##or q-values
     regdict={}
     for row in new_results:
         tfs=[t for t in row[0].split(delim) if t!='' and ' ' not in t]
 	#print row
         if str(row[1])=='nan':
-            continue    
+            continue
+        # skip rows that exceed the q-value or p-value threhsold
         if opts.use_qval:
-            if row[4]>float(opts.thresh):
+            if row[4]>threshold:
                 continue
-        elif row[2]>float(opts.thresh):
+        elif row[2]>threshold:
             continue
         for tf in tfs:
             if row[2]==1:
                 continue
             if opts.use_qval:
-                lpv=-1.0*np.log2(float(row[4]))#calculate neg log pvalue
+                lpv=-1.0*np.log2(float(row[4]))#calculate neg log2 qvalue
             else:
-                lpv=-1.0*np.log2(float(row[2]))#calculate neg log pvalue
+                lpv=-1.0*np.log2(float(row[2]))#calculate neg log2 pvalue
             try:
                 cpv=regdict[tf]
             except KeyError:


### PR DESCRIPTION
This pull request fixes a few bugs in Garnet's `motif_regression.py`:
- Use the p-value to filter significant motifs in the Garnet output HTML file when a p-value threshold was specified in the config file.  Previously the q-value was always used.
- Respect the `savePlot` config file setting.  Previously plots were erroneously always saved.
- Updated README to make it clear that Forest prizes from Garnet are -log2 transformed, not -log10 transformed.

I'll leave this open for a few days for comments and merge if there are not any.

I suggest we update the Omics Integration version number after merging this.  There have been many bug fixes and almost 100 commits since [v0.2](https://github.com/fraenkel-lab/OmicsIntegrator/releases/tag/v0.2).