### PR TITLE
Set max networkx, numpy, and scipy versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel>=0.23.0
 networkx>=1.4,<2
 numpy>=1.6
-scipy>=0.9.0
+scipy>=0.9.0,<1
 matplotlib>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel>=0.23.0
 networkx>=1.4,<2
-numpy>=1.6
+numpy>=1.6,<1.14
 scipy>=0.9.0,<1
 matplotlib>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel>=0.23.0
-networkx>=1.4
+networkx>=1.4,<2
 numpy>=1.6
 scipy>=0.9.0
 matplotlib>=1.0


### PR DESCRIPTION
Impose a maximum supported networkx version in `requirements.txt`.

Closes #28.